### PR TITLE
Fix for the $appHardwarePlatform condition

### DIFF
--- a/Citrix/Virtual Delivery Agent/Install-RemotePC-CR.ps1
+++ b/Citrix/Virtual Delivery Agent/Install-RemotePC-CR.ps1
@@ -264,7 +264,7 @@ If ($appVersion -gt $appInstalledVersion) {
     # Set-RegistryKey -Key "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" -Name "HiberbootEnabled" -Type "DWord" -Value "0"
 
     # Session disconnects when you select Ctrl+Alt+Del on the machine that has session management notification enabled - https://docs.citrix.com/en-us/citrix-virtual-apps-desktops/install-configure/remote-pc-access.html
-    If (($appHardwarePlatform -eq "Virtual") -or (Get-WindowsOptionalFeature -FeatureName "Microsoft-Hyper-V" -Online).State -eq "Enabled"){
+    If (($appHardwarePlatform -like "Virtual*") -or (Get-WindowsOptionalFeature -FeatureName "Microsoft-Hyper-V" -Online).State -eq "Enabled"){
         Set-RegistryKey -Key "HKLM:\SOFTWARE\Citrix\PortICA" -Name "ForceEnableRemotePC" -Type "DWord" -Value "1"
     }
 


### PR DESCRIPTION
Get-HardwarePlatform returns "Virtual:VMWare" on my VMWare machine.  The registry key was not created because $appHardwarePlatform -eq "Virtual" was false.